### PR TITLE
Nginx proxy: get SSL working

### DIFF
--- a/docker/homebridge/docker-compose.yml
+++ b/docker/homebridge/docker-compose.yml
@@ -4,11 +4,6 @@ services:
     image: oznu/homebridge:latest
     restart: unless-stopped
     network_mode: nginx-proxy_default
-    ports:
-      # note: we want the container's internal port 8581 exposed, but we don't
-      # want it mapped to one of the host's ports. (see the nginx-proxy VIRTUAL_PORT
-      # environment variable below)
-      - "8581"
     volumes:
       - ./volumes/homebridge:/homebridge
     dns:
@@ -16,8 +11,13 @@ services:
       - 127.0.0.1
     environment:
       # note: remember to run docker/pihole/bin/add_custom_dns.sh before starting this
-      - VIRTUAL_HOST=homebridge.pihome.run
-      - VIRTUAL_PORT=8581
+      - 'VIRTUAL_HOST=homebridge.pihome.run'
+      # note: we want the container's internal port 8581 exposed, but we don't
+      # want it mapped to one of the host's ports. homebridge runs on port 8581 by default,
+      # and we need nginx-proxy to know about it, but we don't have this port exposed via a
+      # services.homebridge.ports item.
+      - 'VIRTUAL_PORT=8581'
+      - 'CERT_NAME=pihome.run'
     logging:
       driver: json-file
       options:

--- a/docker/homebridge/docker-compose.yml
+++ b/docker/homebridge/docker-compose.yml
@@ -1,11 +1,23 @@
-version: '2'
+version: '3'
 services:
   homebridge:
     image: oznu/homebridge:latest
-    restart: always
-    network_mode: host
+    restart: unless-stopped
+    network_mode: nginx-proxy_default
+    ports:
+      # note: we want the container's internal port 8581 exposed, but we don't
+      # want it mapped to one of the host's ports. (see the nginx-proxy VIRTUAL_PORT
+      # environment variable below)
+      - "8581"
     volumes:
       - ./volumes/homebridge:/homebridge
+    dns:
+      # pihole is handling DNS, so make sure it's running first
+      - 127.0.0.1
+    environment:
+      # note: remember to run docker/pihole/bin/add_custom_dns.sh before starting this
+      - VIRTUAL_HOST=homebridge.pihome.run
+      - VIRTUAL_PORT=8581
     logging:
       driver: json-file
       options:

--- a/docker/homebridge/docker-compose.yml
+++ b/docker/homebridge/docker-compose.yml
@@ -14,8 +14,8 @@ services:
       - 'VIRTUAL_HOST=homebridge.pihome.run'
       # note: we want the container's internal port 8581 exposed, but we don't
       # want it mapped to one of the host's ports. homebridge runs on port 8581 by default,
-      # and we need nginx-proxy to know about it, but we don't have this port exposed via a
-      # services.homebridge.ports item.
+      # and we need nginx-proxy to know about it, but we don't have the host's port 8581
+      # exposed via a services.homebridge.ports item.
       - 'VIRTUAL_PORT=8581'
       - 'CERT_NAME=pihome.run'
     logging:

--- a/docker/nginx-proxy/bin/generate_certs.sh
+++ b/docker/nginx-proxy/bin/generate_certs.sh
@@ -64,4 +64,9 @@ fi
 
 echoerr "done creating the self-signed x509 cert. make sure this cert is in the appropriate \
 place for nginx-proxy to find (probably $CERTS_DIR_SUFFIX within whatever dir you run \
-\`docker compose\` from)"
+\`docker compose\` from). Also add the pihome-ca.pem to whichever computers you plan to access the \
+pihome UIs from:"
+
+echoerr 'copy the CA cert to your machine. From your machine, run:'
+echoerr "        scp $(whoami)@$(hostname).local:${CA_CREATION_DIR}/pihome-ca.pem ~/Downloads"
+echoerr 'then tell your OS to recognize this CA cert and trust it (e.g. with Keychain Access on MacOS).'

--- a/docker/nginx-proxy/bin/generate_certs.sh
+++ b/docker/nginx-proxy/bin/generate_certs.sh
@@ -14,16 +14,50 @@ PARENT_DIR=$(dirname "$SCRIPT_DIR")
 CERTS_DIR_SUFFIX="etc-nginx-proxy/ssl/certs"
 CERTS_DIR="$PARENT_DIR/$CERTS_DIR_SUFFIX"
 
-if [ ! -d "$CERTS_DIR" ]; then
+if [ -d "$CERTS_DIR" ]; then
+  echoerr "it looks like a certificates directory already exists: \`$CERTS_DIR\`. If you need new certificates \
+  remove this directory."
+else
   echoerr "creating $CERTS_DIR"
   mkdir -p "$CERTS_DIR"
+  echoerr "creating a local root CA private key for LAN-hosted pages"
+  openssl genrsa -des3 -out "${CERTS_DIR}/pihome-ca.key" 4096
+
+  echoerr "creating a local certificate with that root CA private key"
+  openssl req -x509 -new -nodes -key "${CERTS_DIR}/pihome-ca.key" -sha256 -days 3650 -out "${CERTS_DIR}/pihome-ca.pem" -subj "/CN=pihome-ca.run"
+
+  echoerr "copying the pihome-ca cert to the ca-certificates dir"
+  sudo cp "${CERTS_DIR}/pihome-ca.pem" /usr/local/share/ca-certificates/pihome-ca.crt
+
+  echoerr "updating the certificates store"
+  sudo update-ca-certificates
+
+  echoerr "creating the x509 cert extension config file to attach the SANs"
+  printf '%s\n' \
+    "authorityKeyIdentifier=keyid,issuer" \
+    "basicConstraints=CA:FALSE" \
+    "keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment" \
+    "subjectAltName = @alt_names" \
+    "" \
+    "[alt_names]" \
+    "DNS.1 = pihome.run" \
+    "DNS.2 = pihole.pihome.run" \
+    "DNS.1 = homebridge.pihome" \
+  > "${CERTS_DIR}/pihome.run.ext"
+
+  openssl x509 -req -in "${CERTS_DIR}/pihome.run.csr" -CA "${CERTS_DIR}/pihome-ca.pem" -CAkey "${CERTS_DIR}/pihome-ca.key"\
+  -CAcreateserial -out "${CERTS_DIR}pihome.run.crt" -days 3650 -sha256 -extfile "${CERTS_DIR}/pihome.run.ext"
 fi
 
 echoerr "creating self signed x509 cert for pihome nginx-proxy to use"
 
-openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -trustout \
-  -keyout "$CERTS_DIR/pihome.run.key" -out "$CERTS_DIR/pihome.run.crt" -subj "/CN=pihome.run"\
-  -addext "subjectAltName=DNS:pihome.run,DNS:www.pihome.run,DNS:homebridge.pihome.run,DNS:pihole.pihome.run"
+openssl genrsa -out "${CERTS_DIR}/pihome.run.key" 4096
+openssl req -new -key "${CERTS_DIR}/pihome.run.key" -out "${CERTS_DIR}/pihome.run.csr"
+
+
+
+#can't do the oneliner below because `openssl req` doesn't support -trustout
+# openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout "home.run.key" -out "home.run.crt" -subj "/CN=pihome.run" -addext "subjectAltName=DNS:pihome.run,DNS:www.pihome.run,DNS:homebridge.pihome.run,DNS:pihole.pihome.run"
 
 echoerr "done creating the self-signed x509 cert. make sure this cert is in the appropriate \
 place for nginx-proxy to find (probably $CERTS_DIR_SUFFIX within whatever dir you run \

--- a/docker/nginx-proxy/bin/generate_certs.sh
+++ b/docker/nginx-proxy/bin/generate_certs.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+echoerr() {
+  printf "%s\n" "$*" >&2
+}
+
+
+if ! command -v openssl &> /dev/null; then
+  echoerr "\`openssl\` is not installed on this machine. install it with apt-get"
+  exit 1
+fi
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+PARENT_DIR=$(dirname "$SCRIPT_DIR")
+CERTS_DIR_SUFFIX="etc-nginx-proxy/ssl/certs"
+CERTS_DIR="$PARENT_DIR/$CERTS_DIR_SUFFIX"
+
+if [ -d "$CERTS_DIR" ]; then
+  mkdir -p"$CERTS_DIR"
+fi
+
+echoerr "creating self signed x509 cert for pihome nginx-proxy to use"
+
+openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes \
+  -keyout "$CERTS_DIR/pihome.run.key" -out "$CERTS_DIR/pihome.run.crt" -subj "/CN=pihome.run"
+
+echoerr "done creating the self-signed x509 cert. make sure this cert is in the appropriate \
+place for nginx-proxy to find (probably $CERTS_DIR_SUFFIX within whatever dir you run \
+\`docker compose\` from)"

--- a/docker/nginx-proxy/bin/generate_certs.sh
+++ b/docker/nginx-proxy/bin/generate_certs.sh
@@ -52,11 +52,11 @@ else
     "[alt_names]" \
     "DNS.1 = pihome.run" \
     "DNS.2 = pihole.pihome.run" \
-    "DNS.1 = homebridge.pihome" \
+    "DNS.3 = homebridge.pihome.run" \
   > "${CERT_CREATION_DIR}/pihome.run.ext"
 
-  openssl x509 -req -in "${CERT_CREATION_DIR}/pihome.run.csr" -CA "${CA_CREATION_DIR}/pihome-ca.pem" -CAkey "${CA_CREATION_DIR}/pihome-ca.key"\
-  -CAcreateserial -out "${CERT_CREATION_DIR}pihome.run.crt" -days 3650 -sha256 -extfile "${CERT_CREATION_DIR}/pihome.run.ext"
+  openssl x509 -trustout -req -in "${CERT_CREATION_DIR}/pihome.run.csr" -CA "${CA_CREATION_DIR}/pihome-ca.pem" -CAkey "${CA_CREATION_DIR}/pihome-ca.key" \
+  -CAcreateserial -out "${CERT_CREATION_DIR}/pihome.run.crt" -days 3650 -sha256 -extfile "${CERT_CREATION_DIR}/pihome.run.ext"
 fi
 
 #can't do the oneliner below because `openssl req` doesn't support -trustout

--- a/docker/nginx-proxy/bin/generate_certs.sh
+++ b/docker/nginx-proxy/bin/generate_certs.sh
@@ -15,7 +15,7 @@ CERTS_DIR_SUFFIX="etc-nginx-proxy/ssl/certs"
 CERTS_DIR="$PARENT_DIR/$CERTS_DIR_SUFFIX"
 
 if [ -d "$CERTS_DIR" ]; then
-  mkdir -p"$CERTS_DIR"
+  mkdir -p "$CERTS_DIR"
 fi
 
 echoerr "creating self signed x509 cert for pihome nginx-proxy to use"

--- a/docker/nginx-proxy/bin/generate_certs.sh
+++ b/docker/nginx-proxy/bin/generate_certs.sh
@@ -14,7 +14,7 @@ PARENT_DIR=$(dirname "$SCRIPT_DIR")
 CERTS_DIR_SUFFIX="etc-nginx-proxy/ssl/certs"
 CERTS_DIR="$PARENT_DIR/$CERTS_DIR_SUFFIX"
 
-if [ -d "$CERTS_DIR" ]; then
+if [ ! -d "$CERTS_DIR" ]; then
   echoerr "creating $CERTS_DIR"
   mkdir -p "$CERTS_DIR"
 fi

--- a/docker/nginx-proxy/bin/generate_certs.sh
+++ b/docker/nginx-proxy/bin/generate_certs.sh
@@ -21,7 +21,7 @@ fi
 
 echoerr "creating self signed x509 cert for pihome nginx-proxy to use"
 
-openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes \
+openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -trustout \
   -keyout "$CERTS_DIR/pihome.run.key" -out "$CERTS_DIR/pihome.run.crt" -subj "/CN=pihome.run"\
   -addext "subjectAltName=DNS:pihome.run,DNS:www.pihome.run,DNS:homebridge.pihome.run,DNS:pihole.pihome.run"
 

--- a/docker/nginx-proxy/bin/generate_certs.sh
+++ b/docker/nginx-proxy/bin/generate_certs.sh
@@ -22,7 +22,8 @@ fi
 echoerr "creating self signed x509 cert for pihome nginx-proxy to use"
 
 openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes \
-  -keyout "$CERTS_DIR/pihome.run.key" -out "$CERTS_DIR/pihome.run.crt" -subj "/CN=pihome.run"
+  -keyout "$CERTS_DIR/pihome.run.key" -out "$CERTS_DIR/pihome.run.crt" -subj "/CN=pihome.run"\
+  -addext "subjectAltName=DNS:pihome.run,DNS:www.pihome.run,DNS:homebridge.pihome.run,DNS:pihole.pihome.run"
 
 echoerr "done creating the self-signed x509 cert. make sure this cert is in the appropriate \
 place for nginx-proxy to find (probably $CERTS_DIR_SUFFIX within whatever dir you run \

--- a/docker/nginx-proxy/bin/generate_certs.sh
+++ b/docker/nginx-proxy/bin/generate_certs.sh
@@ -12,25 +12,35 @@ fi
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 PARENT_DIR=$(dirname "$SCRIPT_DIR")
 CERTS_DIR_SUFFIX="etc-nginx-proxy/ssl/certs"
-CERTS_DIR="$PARENT_DIR/$CERTS_DIR_SUFFIX"
+CA_CREATION_DIR="${PARENT_DIR}/ssl/ca"
+CERT_CREATION_DIR="${PARENT_DIR}/ssl/certs"
 
-if [ -d "$CERTS_DIR" ]; then
-  echoerr "it looks like a certificates directory already exists: \`$CERTS_DIR\`. If you need new certificates \
+if [ -d "$CA_CREATION_DIR" ]; then
+  echoerr "it looks like a certificates directory already exists: \`$CA_CREATION_DIR\`. If you need new certificates \
   remove this directory."
 else
-  echoerr "creating $CERTS_DIR"
-  mkdir -p "$CERTS_DIR"
+  echoerr "creating $CA_CREATION_DIR"
+  mkdir -p "$CA_CREATION_DIR"
+
   echoerr "creating a local root CA private key for LAN-hosted pages"
-  openssl genrsa -des3 -out "${CERTS_DIR}/pihome-ca.key" 4096
+  openssl genrsa -des3 -out "${CA_CREATION_DIR}/pihome-ca.key" 4096
 
   echoerr "creating a local certificate with that root CA private key"
-  openssl req -x509 -new -nodes -key "${CERTS_DIR}/pihome-ca.key" -sha256 -days 3650 -out "${CERTS_DIR}/pihome-ca.pem" -subj "/CN=pihome-ca.run"
+  openssl req -x509 -new -nodes -key "${CA_CREATION_DIR}/pihome-ca.key" -sha256 -days 3650 -out "${CA_CREATION_DIR}/pihome-ca.pem" -subj "/CN=pihome-ca.run"
 
   echoerr "copying the pihome-ca cert to the ca-certificates dir"
-  sudo cp "${CERTS_DIR}/pihome-ca.pem" /usr/local/share/ca-certificates/pihome-ca.crt
+  sudo cp "${CA_CREATION_DIR}/pihome-ca.pem" /usr/local/share/ca-certificates/pihome-ca.crt
 
   echoerr "updating the certificates store"
   sudo update-ca-certificates
+
+  echoerr "creating a certificate from our ca certificate"
+  mkdir -p "$CERT_CREATION_DIR"
+
+  echoerr "creating self signed x509 cert for pihome nginx-proxy to use"
+
+  openssl genrsa -out "${CERT_CREATION_DIR}/pihome.run.key" 4096
+  openssl req -new -key "${CERT_CREATION_DIR}/pihome.run.key" -out "${CERT_CREATION_DIR}/pihome.run.csr"
 
   echoerr "creating the x509 cert extension config file to attach the SANs"
   printf '%s\n' \
@@ -43,18 +53,11 @@ else
     "DNS.1 = pihome.run" \
     "DNS.2 = pihole.pihome.run" \
     "DNS.1 = homebridge.pihome" \
-  > "${CERTS_DIR}/pihome.run.ext"
+  > "${CERT_CREATION_DIR}/pihome.run.ext"
 
-  openssl x509 -req -in "${CERTS_DIR}/pihome.run.csr" -CA "${CERTS_DIR}/pihome-ca.pem" -CAkey "${CERTS_DIR}/pihome-ca.key"\
-  -CAcreateserial -out "${CERTS_DIR}pihome.run.crt" -days 3650 -sha256 -extfile "${CERTS_DIR}/pihome.run.ext"
+  openssl x509 -req -in "${CERT_CREATION_DIR}/pihome.run.csr" -CA "${CA_CREATION_DIR}/pihome-ca.pem" -CAkey "${CA_CREATION_DIR}/pihome-ca.key"\
+  -CAcreateserial -out "${CERT_CREATION_DIR}pihome.run.crt" -days 3650 -sha256 -extfile "${CERT_CREATION_DIR}/pihome.run.ext"
 fi
-
-echoerr "creating self signed x509 cert for pihome nginx-proxy to use"
-
-openssl genrsa -out "${CERTS_DIR}/pihome.run.key" 4096
-openssl req -new -key "${CERTS_DIR}/pihome.run.key" -out "${CERTS_DIR}/pihome.run.csr"
-
-
 
 #can't do the oneliner below because `openssl req` doesn't support -trustout
 # openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout "home.run.key" -out "home.run.crt" -subj "/CN=pihome.run" -addext "subjectAltName=DNS:pihome.run,DNS:www.pihome.run,DNS:homebridge.pihome.run,DNS:pihole.pihome.run"

--- a/docker/nginx-proxy/bin/generate_certs.sh
+++ b/docker/nginx-proxy/bin/generate_certs.sh
@@ -15,6 +15,7 @@ CERTS_DIR_SUFFIX="etc-nginx-proxy/ssl/certs"
 CERTS_DIR="$PARENT_DIR/$CERTS_DIR_SUFFIX"
 
 if [ -d "$CERTS_DIR" ]; then
+  echoerr "creating $CERTS_DIR"
   mkdir -p "$CERTS_DIR"
 fi
 

--- a/docker/nginx-proxy/docker-compose.yml
+++ b/docker/nginx-proxy/docker-compose.yml
@@ -12,3 +12,4 @@ services:
       # todo: set up SSL for this
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./etc-nginx-proxy/ssl/certs/:/etc/nginx/certs

--- a/docker/nginx-proxy/docker-compose.yml
+++ b/docker/nginx-proxy/docker-compose.yml
@@ -9,7 +9,9 @@ services:
     image: jwilder/nginx-proxy
     ports:
       - "80:80"
-      # todo: set up SSL for this
+      - "443:443"
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - ./etc-nginx-proxy/ssl/certs/:/etc/nginx/certs
+    environment:
+      - 'CERT_NAME=pihome.run'

--- a/docker/nginx-proxy/docker-compose.yml
+++ b/docker/nginx-proxy/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+
+
+# note: this must be started before other UIs. this nginx-proxy service does some
+# magic listening to the docker socket to figure out what containers' exposed ports
+# to proxy to
+services:
+  nginx-proxy:
+    image: jwilder/nginx-proxy
+    ports:
+      - "80:80"
+      # todo: set up SSL for this
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro

--- a/docker/pihole/bin/add_custom_dns.sh
+++ b/docker/pihole/bin/add_custom_dns.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+echoerr() {
+  printf "%s\n" "$*" >&2
+}
+
+if ! command -v ip &> /dev/null; then
+  echoerr "\`ip\` does not exist on this machine, so we cannot build the \`custom.list\` DNS file"
+  exit 1
+fi
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+PARENT_DIR=$(dirname "$SCRIPT_DIR")
+ETC_PIHOLE_DIR="$PARENT_DIR/etc-pihole"
+CUSTOM_PIHOLE_DNS_FILE="$ETC_PIHOLE_DIR/custom.list"
+
+IP4=$(ip -o -4  addr list eth0 | awk '{print $4}' | cut -d/ -f1)
+
+echoerr "the LAN address of the eth0 interface is ${IP4}"
+
+if [ ! -d "$ETC_PIHOLE_DIR" ]; then
+  mkdir "$ETC_PIHOLE_DIR"
+fi
+
+
+cat <<EOF > "$CUSTOM_PIHOLE_DNS_FILE"
+$IP4 pihome.run
+$IP4 homebridge.pihome.run
+$IP4 pihole.pihome.run
+EOF
+
+echoerr "added ip4: $IP4 entries to $CUSTOM_PIHOLE_DNS_FILE"
+echoerr "confirm that the \`etc-pihole\` directory and docker-compose.yml file \
+are in the same directory to ensure that docker compose mounts volumes properly"

--- a/docker/pihole/docker-compose.yml
+++ b/docker/pihole/docker-compose.yml
@@ -14,7 +14,8 @@ services:
     environment:
       - 'TZ=America/New_York'
       # note: remember to run docker/pihole/bin/add_custom_dns.sh before starting this
-      - VIRTUAL_HOST=pihole.pihome.run
+      - 'VIRTUAL_HOST=pihole.pihome.run'
+      - 'CERT_NAME=CERT_NAME=pihome.run'
     volumes:
        - './etc-pihole/:/etc/pihole/'
        - './etc-dnsmasq.d/:/etc/dnsmasq.d/'

--- a/docker/pihole/docker-compose.yml
+++ b/docker/pihole/docker-compose.yml
@@ -5,19 +5,24 @@ services:
     container_name: pihole
     image: pihole/pihole:latest
     ports:
+      # note: unlike the DNS ports, we want the UI on the container's internal port 80 exposed,
+      # but we don't want it mapped to the host's port 80. this is how nginx-proxy hooks in
+      - "80"
       - "53:53/tcp"
       - "53:53/udp"
       - "67:67/udp"
-      - "80:80/tcp"
-      - "443:443/tcp"
     environment:
-      TZ: 'America/New_York'
+      - 'TZ=America/New_York'
+      # note: remember to run docker/pihole/bin/add_custom_dns.sh before starting this
+      - VIRTUAL_HOST=pihole.pihome.run
     volumes:
        - './etc-pihole/:/etc/pihole/'
        - './etc-dnsmasq.d/:/etc/dnsmasq.d/'
     dns:
       - 127.0.0.1
       - 1.1.1.1
+    # note: this network_mode should point to the nginx-proxy's network
+    network_mode: nginx-proxy_default
     cap_add:
       - NET_ADMIN
     restart: unless-stopped

--- a/docker/pihole/docker-compose.yml
+++ b/docker/pihole/docker-compose.yml
@@ -5,9 +5,6 @@ services:
     container_name: pihole
     image: pihole/pihole:latest
     ports:
-      # note: unlike the DNS ports, we want the UI on the container's internal port 80 exposed,
-      # but we don't want it mapped to the host's port 80. this is how nginx-proxy hooks in
-      - "80"
       - "53:53/tcp"
       - "53:53/udp"
       - "67:67/udp"
@@ -15,6 +12,11 @@ services:
       - 'TZ=America/New_York'
       # note: remember to run docker/pihole/bin/add_custom_dns.sh before starting this
       - 'VIRTUAL_HOST=pihole.pihome.run'
+      # note: we want the container's internal port 80 exposed, but we don't
+      # want it mapped to one of the host's ports. The pihole UI runs on port 80 by default,
+      # and we need nginx-proxy to know about it, but we don't have the host's port 80
+      # exposed via a services.homebridge.ports item.
+      - 'VIRTUAL_PORT=80'
       - 'CERT_NAME=CERT_NAME=pihome.run'
     volumes:
        - './etc-pihole/:/etc/pihole/'


### PR DESCRIPTION
this adds a script to generate a root certificate, create new certificates from that root certificate, and run [nginx-proxy](https://github.com/nginx-proxy/nginx-proxy) to use those certificates and proxy the requests to the appropriate containers. It also adds a script to generate the `someapp.pihome.run` subdomain DNS entries for pihole to use. The SANs in the generated certificate and the `someapp.pihome.run` DNS entries should be kept in sync.