### PR TITLE
Apt get instead of apt

### DIFF
--- a/bin/install_and_configure_git.sh
+++ b/bin/install_and_configure_git.sh
@@ -19,20 +19,20 @@ install_package_if_absent() {
   fi
 }
 
-echoerr "updating and upgrading apt..."
+echoerr "updating and upgrading apt-get..."
 
 
-if ! sudo apt update; then
+if ! sudo apt-get update --assume-yes; then
   echoerr "something went wrong updating apt"
   exit 1
 fi
 
-if ! sudo apt upgrade; then
+if ! sudo apt-get upgrade --assume-yes; then
   echoerr "something went wrong upgrading packages"
   exit 1
 fi
 
-echoerr "apt is up to date. moving on"
+echoerr "apt-get is up to date. moving on"
 
 echoerr "checking git..."
 install_package_if_absent 'git'

--- a/bin/install_and_configure_git.sh
+++ b/bin/install_and_configure_git.sh
@@ -9,13 +9,13 @@ echoerr() {
 
 # a copy of install_package_if_absent so we can curl/download the script from raw.githubusercontent.com/...
 install_package_if_absent() {
-  DEP_NAME=$1
+  local dep_name=$1
 
-  if dpkg-query -W -f='${Status}\n' "$DEP_NAME" 2> /dev/null | grep -q 'ok installed'; then
-    echoerr "$DEP_NAME is already installed. nothing to do here."
+  if dpkg-query -W -f='${Status}\n' "$dep_name" 2> /dev/null | grep -q 'ok installed'; then
+    echoerr "$dep_name is already installed. nothing to do here."
   else
-    echoerr "$DEP_NAME is not yet installed. Installing it now."
-    sudo apt-get install --assume-yes "$DEP_NAME"
+    echoerr "$dep_name is not yet installed. Installing it now."
+    sudo apt-get install --assume-yes "$dep_name"
   fi
 }
 
@@ -49,7 +49,7 @@ fi
 
 # ssh -T returns 1 on success, other nonzero code on failure
 ssh -o StrictHostKeyChecking=no -T git@github.com 1>/dev/null 2>&1 || EXIT_CODE=$?
-if [[ ${EXIT_CODE} != 1 ]]; then
+if [ "$EXIT_CODE" -ne 1 ]; then
   echoerr "failed to authenticate with github. you need to add your new ssh key to your github account"
   echoerr "> https://docs.github.com/en/repositories/creating-and-managing-repositories/troubleshooting-cloning-errors#check-your-ssh-access"
   exit 1

--- a/bin/install_package_if_absent.sh
+++ b/bin/install_package_if_absent.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # since the path building here is dynamic,
 # shellcheck disable=SC1091
-source "$DIR/echoerr.sh"
+source "$dir/echoerr.sh"
 
 install_package_if_absent() {
-  DEP_NAME=$1
+  local dep_name=$1
 
-  if dpkg-query -W -f='${Status}\n' "$DEP_NAME" 2> /dev/null | grep -q 'ok installed'; then
-    echoerr "$DEP_NAME is already installed. nothing to do here."
+  if dpkg-query -W -f='${Status}\n' "$dep_name" 2> /dev/null | grep -q 'ok installed'; then
+    echoerr "$dep_name is already installed. nothing to do here."
   else
-    echoerr "$DEP_NAME is not yet installed. Installing it now."
-    sudo apt-get install --assume-yes "$DEP_NAME"
+    echoerr "$dep_name is not yet installed. Installing it now."
+    sudo apt-get install --assume-yes "$dep_name"
   fi
 }


### PR DESCRIPTION
this allows me to pass the `--assume-yes` flag, which allows the script to complete without any additional prodding. it also fixes some bash syntax stuff like using lowercase variable names for non-exported variables and using regular, single bracket `test` instead of extended test syntax (the double brackets) for the install-and-configure-git.sh script, which gets executed with `sh` instead of `bash`